### PR TITLE
fix(output): set aws region as start mode output

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -51878,9 +51878,10 @@ const config = __nccwpck_require__(4570)
 const core = __nccwpck_require__(2186)
 const { waitForRunnerRegistered } = __nccwpck_require__(6989)
 
-function setOutput(label, ec2InstanceId) {
+function setOutput(label, ec2InstanceId, region) {
   core.setOutput('label', label)
   core.setOutput('ec2-instance-id', ec2InstanceId)
+  core.setOutput('aws-region', region)
 }
 
 async function start() {
@@ -51897,7 +51898,8 @@ async function start() {
 
   setOutput(
     start_instance_response.runner_name,
-    wait_instance_response.instance_id
+    wait_instance_response.instance_id,
+    start_instance_response.aws_region
   )
 
   await waitForRunnerRegistered(start_instance_response.runner_name)

--- a/src/index.js
+++ b/src/index.js
@@ -3,9 +3,10 @@ const config = require('./config')
 const core = require('@actions/core')
 const { waitForRunnerRegistered } = require('./gh')
 
-function setOutput(label, ec2InstanceId) {
+function setOutput(label, ec2InstanceId, region) {
   core.setOutput('label', label)
   core.setOutput('ec2-instance-id', ec2InstanceId)
+  core.setOutput('aws-region', region)
 }
 
 async function start() {
@@ -22,7 +23,8 @@ async function start() {
 
   setOutput(
     start_instance_response.runner_name,
-    wait_instance_response.instance_id
+    wait_instance_response.instance_id,
+    start_instance_response.aws_region
   )
 
   await waitForRunnerRegistered(start_instance_response.runner_name)


### PR DESCRIPTION
This is useful when caller workflow provides a profile for stop mode and if associated PR tends to be merged before instance teardown. In that case Slab will try to fetch the remote configuration file (slab.toml) on a reference that has vanished thus resulting in an error in Slab without terminating the instance.
Using the region as input for stop mode avoid trying to fetch slab.toml file.