### PR TITLE
feat(config): support generic backend provider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,11 +57,10 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.SLAB_ACTION_TOKEN }}
-          slab-url: ${{ secrets.SLAB_BASE_URL }}
+          slab-url: ${{ secrets.SLAB_BASE_URL_PRE_PROD }}
           job-secret: ${{ secrets.JOB_SECRET }}
-          region: eu-west-3
-          ec2-image-id: ami-01d21b7be69801c2f # Ubuntu 22.04
-          ec2-instance-type: t3.2xlarge
+          backend: aws
+          profile: ci-test
 
       - name: Test stop instance
         id: test-stop
@@ -70,29 +69,6 @@ jobs:
         with:
           mode: stop
           github-token: ${{ secrets.SLAB_ACTION_TOKEN }}
-          slab-url: ${{ secrets.SLAB_BASE_URL }}
+          slab-url: ${{ secrets.SLAB_BASE_URL_PRE_PROD }}
           job-secret: ${{ secrets.JOB_SECRET }}
-          region: eu-west-3
           label: ${{ steps.test-start.outputs.label }}
-
-      - name: Test start instance with profile
-        id: test-start-profile
-        uses: ./
-        with:
-          mode: start
-          github-token: ${{ secrets.SLAB_ACTION_TOKEN }}
-          slab-url: ${{ secrets.SLAB_BASE_URL }}
-          job-secret: ${{ secrets.JOB_SECRET }}
-          profile: ci-test
-
-      - name: Test stop instance with profile
-        id: test-stop-profile
-        if: ${{ always() }}
-        uses: ./
-        with:
-          mode: stop
-          github-token: ${{ secrets.SLAB_ACTION_TOKEN }}
-          slab-url: ${{ secrets.SLAB_BASE_URL }}
-          job-secret: ${{ secrets.JOB_SECRET }}
-          profile: ci-test
-          label: ${{ steps.test-start-profile.outputs.label }}

--- a/README.md
+++ b/README.md
@@ -21,30 +21,25 @@ See [below](#example) the YAML code of the depicted workflow.
 
 ### Inputs
 
-| Name                 | Required                                                          | Description                                                                                                                                                                                                     |
-|----------------------|-------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `mode`               | Always required.                                                  | Specify here which mode you want to use: `start` to start a new runner, `stop` to stop the previously created runner.                                                                                           |
-| `github-token`       | Always required.                                                  | GitHub Personal Access Token with the `repo` scope assigned.                                                                                                                                                    |
-| `slab-url`           | Always required.                                                  | URL to Slab CI server.                                                                                                                                                                                          |
-| `job-secret`         | Always required.                                                  | Secret key used by Slab to perform HMAC computation.                                                                                                                                                            |
-| `profile`            | Optional.                                                         | Profile to use as described slab.toml file in repository that uses the action.                                                                                                                                  |
-| `region`             | Required if you don't use `profile`.                              | AWS deploy region.                                                                                                                                                                                              |
-| `ec2-image-id`       | Required if you don't use `profile` with `start` mode.            | EC2 Image ID (AMI).The new runner will be launched from this image. The action is compatible with Amazon Linux 2 images.                                                                                        |
-| `ec2-instance-type`  | Required if you don't use `profile` with `start` mode.            | EC2 Instance Type.                                                                                                                                                                                              |
-| `subnet-id`          | Optional. Used only if you don't use `profile` with `start` mode. | VPC Subnet ID.The subnet should belong to the same VPC as the specified security group.                                                                                                                         |
-| `security-group-ids` | Optional. Used only if you don't use `profile` with `start` mode. | EC2 Security Group IDs.The security group should belong to the same VPC as the specified subnet.Only the outbound traffic for port 443 should be allowed. No inbound traffic is required.                       |
-| `label`              | Required if you don't use `profile` with `stop` mode.             | Name of the unique label assigned to the runner.The label is provided by the output of the action in the `start` mode.The label is used to remove the runner from GitHub when the runner is not needed anymore. |
+| Name           | Required                    | Description                                                                                                                                                                                                     |
+|----------------|-----------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `mode`         | Always required.            | Specify here which mode you want to use: `start` to start a new runner, `stop` to stop the previously created runner.                                                                                           |
+| `github-token` | Always required.            | GitHub Personal Access Token with the `repo` scope assigned.                                                                                                                                                    |
+| `slab-url`     | Always required.            | URL to Slab CI server.                                                                                                                                                                                          |
+| `job-secret`   | Always required.            | Secret key used by Slab to perform HMAC computation.                                                                                                                                                            |
+| `backend`      | Required with `start` mode. | Backend provider name to look for in slab.toml file in repository that uses the action.                                                                                                                         |
+| `profile`      | Required with `start` mode. | Profile to use as described slab.toml file in repository that uses the action.                                                                                                                                  |
+| `label`        | Required with `stop` mode.  | Name of the unique label assigned to the runner.The label is provided by the output of the action in the `start` mode.The label is used to remove the runner from GitHub when the runner is not needed anymore. |
 
 ### Outputs
 
-| Name              | Description                                                                                                                                                                                                           |
-|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `label`           | Name of the unique label assigned to the runner. The label is used in two cases: to use as the input of `runs-on` property for the following jobs and to remove the runner from GitHub when it is not needed anymore. |
-| `ec2-instance-id` | EC2 Instance ID of the created runner.The ID is used to terminate the EC2 instance when the runner is not needed anymore.                                                                                             |
+| Name          | Description                                                                                                                                                                                                           |
+|---------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `label`       | Name of the unique label assigned to the runner. The label is used in two cases: to use as the input of `runs-on` property for the following jobs and to remove the runner from GitHub when it is not needed anymore. |
 
 ### Examples
 
-The workflow showed in the picture above and declared in `do-the-job.yml` looks like this:
+Here's an example workflow. It uses a backend profile declared in `ci/slab.toml` within the calling repository
 
 ```yml
 name: do-the-job
@@ -63,56 +58,7 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          region: eu-west-3
-          ec2-image-id: ami-123
-          ec2-instance-type: t3.nano
-          subnet-id: subnet-123  # Optional
-          security-group-id: sg-123  # Optional
-
-  do-the-job:
-    name: Do the job on the runner
-    needs: start-runner # required to start the main job when the runner is ready
-    runs-on: ${{ needs.start-runner.outputs.label }} # run the job on the newly created runner
-    steps:
-      - name: Hello World
-        run: echo 'Hello World!'
-
-  stop-runner:
-    name: Stop self-hosted EC2 runner
-    needs:
-      - start-runner # required to get output from the start-runner job
-      - do-the-job # required to wait when the main job is done
-    runs-on: ubuntu-latest
-    if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
-    steps:
-      - name: Stop EC2 runner
-        uses: zama-ai/slab-github-runner@v1
-        with:
-          mode: stop
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          region: eu-west-3
-          label: ${{ needs.start-runner.outputs.label }}
-```
-
-Here's the same workflow but using a profile declared in `ci/slab.toml` within the calling repository
-
-```yml
-name: do-the-job
-on: pull_request
-jobs:
-  start-runner:
-    name: Start self-hosted EC2 runner
-    runs-on: ubuntu-latest
-    outputs:
-      label: ${{ steps.start-ec2-runner.outputs.label }}
-      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
-    steps:
-      - name: Start EC2 runner
-        id: start-ec2-runner
-        uses: zama-ai/slab-github-runner@v1
-        with:
-          mode: start
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          backend: aws
           profile: cpu-test
 
   do-the-job:
@@ -131,7 +77,6 @@ jobs:
         with:
           mode: stop
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          profile: cpu-test
           label: ${{ needs.start-runner.outputs.label }}
 ```
 

--- a/action.yaml
+++ b/action.yaml
@@ -23,50 +23,20 @@ inputs:
     description: >-
       Secret key used by Slab to perform HMAC computation.
     required: true
+  backend:
+    description: >-
+      Backend provider name to look for in slab.toml file in repository that uses the action.
+      This input is required if you use the 'start' mode.
+    required: false
   profile:
     description: >-
       Profile to use as described slab.toml file in repository that uses the action.
-    required: false
-  region:
-    description: >-
-      AWS deployment region.
-      Mutually exclusive with 'profile' input.
-    required: false
-  ec2-image-id:
-    description: >-
-      EC2 Image Id (AMI). The new runner will be launched from this image.
       This input is required if you use the 'start' mode.
-      Mutually exclusive with 'profile' input.
-    required: false
-  ec2-instance-type:
-    description: >-
-      EC2 Instance Type. 
-      This input is required if you use the 'start' mode.
-      Mutually exclusive with 'profile' input.
-    required: false
-  subnet-id:
-    description: >-
-      VPC Subnet Id. The subnet should belong to the same VPC as the specified security group.
-      This input is required if you use the 'start' mode.
-      Mutually exclusive with 'profile' input.
-    required: false
-  security-group-ids:
-    description: >-
-      EC2 Security Group Ids. 
-      The security group should belong to the same VPC as the specified subnet.
-      The runner doesn't require any inbound traffic. However, outbound traffic should be allowed.
-      Mutually exclusive with 'profile' input.
     required: false
   label:
     description: >-
       Name of the unique label assigned to the runner.
       The label is used to remove the runner from GitHub when the runner is not needed anymore.
-      This input is required if you use the 'stop' mode.
-    required: false
-  ec2-instance-id:
-    description: >-
-      EC2 Instance Id of the created runner.
-      The id is used to terminate the EC2 instance when the runner is not needed anymore.
       This input is required if you use the 'stop' mode.
     required: false
 

--- a/ci/slab.toml
+++ b/ci/slab.toml
@@ -1,11 +1,9 @@
 # This profile is dedicated to test action behavior by replicating
-#profiles that can be found on repository using this workflow.
-[profile.ci-test]
+# profiles that can be found on repository using this workflow.
+[backend.aws.ci-test]
 region = "eu-west-3"
 image_id = "ami-01d21b7be69801c2f" # Ubuntu 22.04
 instance_type = "t3.2xlarge"
 
-[command.placeholder]
-workflow = "no-workflow.yml"
-profile = "ci-test"
-check_run_name = "Placeholder command to test slab action"
+[profile]
+[command]

--- a/src/config.js
+++ b/src/config.js
@@ -8,12 +8,8 @@ class Config {
       githubToken: core.getInput('github-token'),
       slabUrl: core.getInput('slab-url'),
       jobSecret: core.getInput('job-secret'),
-      profile: core.getInput('profile'),
-      region: core.getInput('region'),
-      ec2ImageId: core.getInput('ec2-image-id'),
-      ec2InstanceType: core.getInput('ec2-instance-type'),
-      subnetId: core.getInput('subnet-id'),
-      securityGroupIds: core.getInput('security-group-ids'),
+      backend: core.getInput('backend').toLowerCase(),
+      profile: core.getInput('profile').toLowerCase(),
       label: core.getInput('label')
     }
 
@@ -47,28 +43,8 @@ class Config {
       throw new Error(`The 'job-secret' input is not specified`)
     }
 
-    if (
-      this.input.profile &&
-      (this.input.region ||
-        this.input.ec2ImageId ||
-        this.input.ec2InstanceType ||
-        this.input.subnetId ||
-        this.input.securityGroupIds)
-    ) {
-      throw new Error(
-        `The 'profile' input is mutually exclusive with any AWS related inputs`
-      )
-    }
-
-    if (!this.input.profile && !this.input.region) {
-      throw new Error(`The 'region' input is not specified`)
-    }
-
     if (this.input.mode === 'start') {
-      if (
-        !this.input.profile &&
-        (!this.input.ec2ImageId || !this.input.ec2InstanceType)
-      ) {
+      if (!this.input.backend || !this.input.profile) {
         throw new Error(
           `Not all the required inputs are provided for the 'start' mode`
         )


### PR DESCRIPTION
Custom AWS instance profile is not available anymore. Any backend profile must come from a slab.toml file in repository that uses the action. Now only the name of the provider and the name of the profile is needed.