### PR TITLE
feat(slab): wait slab until async task is over

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -49766,7 +49766,8 @@ async function startInstanceRequest() {
 }
 
 async function waitForInstance(taskId, taskName) {
-  for (let i = 0; i < 60; i++) {
+  // while (true) equivalent to please ESLint
+  for (;;) {
     await utils.sleep(15)
 
     try {
@@ -49788,19 +49789,16 @@ async function waitForInstance(taskId, taskName) {
           return
         }
       } else {
-        core.error(
+        core.setFailed(
           `Failed to wait for instance (HTTP status code: ${response.status})`
         )
+        return
       }
     } catch (error) {
       core.error('Failed to fetch or remove instance task')
       throw error
     }
   }
-
-  core.setFailed(
-    'Timeout while waiting for instance to be running after 15 mins.'
-  )
 }
 
 async function terminateInstanceRequest(runnerName) {

--- a/src/slab.js
+++ b/src/slab.js
@@ -58,7 +58,8 @@ async function startInstanceRequest() {
 }
 
 async function waitForInstance(taskId, taskName) {
-  for (let i = 0; i < 60; i++) {
+  // while (true) equivalent to please ESLint
+  for (;;) {
     await utils.sleep(15)
 
     try {
@@ -80,19 +81,16 @@ async function waitForInstance(taskId, taskName) {
           return
         }
       } else {
-        core.error(
+        core.setFailed(
           `Failed to wait for instance (HTTP status code: ${response.status})`
         )
+        return
       }
     } catch (error) {
       core.error('Failed to fetch or remove instance task')
       throw error
     }
   }
-
-  core.setFailed(
-    'Timeout while waiting for instance to be running after 15 mins.'
-  )
 }
 
 async function terminateInstanceRequest(runnerName) {


### PR DESCRIPTION
This is done to handle various timeouts configuration on spawn request in Slab. Until now the timeout was set to 15 minutes. This was fine since default spawn timeout in Slab was set to 10 minutes. However in some cases, slab backend profiles can request a longer duration before timeout.
Since the asynchronous task created in Slab will eventually finish, we now simply wait for this moment.