### PR TITLE
feat!: unregister runner using its unique id

### DIFF
--- a/.github/workflows/test_spawn_terminate.yml
+++ b/.github/workflows/test_spawn_terminate.yml
@@ -21,7 +21,9 @@ jobs:
       fail-fast: false
     outputs:
       runner-aws: ${{ steps.gen-output.outputs.runner_aws }}
+      runner-aws-id: ${{ steps.gen-output.outputs.runner_aws_id }}
       runner-hyperstack: ${{ steps.gen-output.outputs.runner_hyperstack }}
+      runner-hyperstack-id: ${{ steps.gen-output.outputs.runner_hyperstack_id }}
     steps:
       - name: Checkout
         id: checkout
@@ -42,6 +44,7 @@ jobs:
         id: gen-output
         run: |
           echo "runner_${{ matrix.provider }}=${{ steps.test-start.outputs.label }}" >> "${GITHUB_OUTPUT}"
+          echo "runner_${{ matrix.provider }}_id=${{ steps.test-start.outputs.id }}" >> "${GITHUB_OUTPUT}"
 
   test-runner-alive-aws:
     name: Test runner is alive (AWS)
@@ -64,8 +67,8 @@ jobs:
     if: ${{ always() && needs.action-start.result != 'skipped' }}
     strategy:
       matrix:
-        runner: [ "${{ needs.action-start.outputs.runner-aws }}",
-                  "${{ needs.action-start.outputs.runner-hyperstack }}" ]
+        runner-id: [ "${{ needs.action-start.outputs.runner-aws-id }}",
+                  "${{ needs.action-start.outputs.runner-hyperstack-id }}" ]
       fail-fast: false
     steps:
       - name: Checkout
@@ -80,7 +83,7 @@ jobs:
           github-token: ${{ secrets.SLAB_ACTION_TOKEN }}
           slab-url: ${{ secrets.SLAB_BASE_URL_PRE_PROD }}
           job-secret: ${{ secrets.JOB_SECRET }}
-          label: ${{ matrix.runner }}
+          runner-id: ${{ matrix.runner-id }}
 
   test-runner-removed-aws:
     name: Test runner is removed (AWS)

--- a/.github/workflows/test_start_stop.yml
+++ b/.github/workflows/test_start_stop.yml
@@ -25,6 +25,8 @@ jobs:
     name: GitHub Actions Test (start)
     runs-on: ubuntu-latest
     needs: [ test-runner-exist ]
+    outputs:
+      runner-id: ${{ steps.test-start.outputs.id }}
     steps:
       - name: Checkout
         id: checkout
@@ -66,7 +68,7 @@ jobs:
           github-token: ${{ secrets.SLAB_ACTION_TOKEN }}
           slab-url: ${{ secrets.SLAB_BASE_URL_PRE_PROD }}
           job-secret: ${{ secrets.JOB_SECRET }}
-          label: ci-persistent-runner
+          runner-id: ${{ needs.action-start.outputs.runner-id}}
 
   test-runner-persist:
     name: Test runner is still registered

--- a/action.yaml
+++ b/action.yaml
@@ -33,10 +33,10 @@ inputs:
       Profile to use as described slab.toml file in repository that uses the action.
       This input is required if you use the 'start' mode.
     required: false
-  label:
+  runner-id:
     description: >-
-      Name of the unique label assigned to the runner.
-      The label is used to remove the runner from GitHub when the runner is not needed anymore.
+      Unique ID assigned to the runner.
+      The runner ID is used to remove the runner from GitHub when the runner is not needed anymore.
       This input is required if you use the 'stop' mode.
     required: false
 
@@ -44,9 +44,11 @@ outputs:
   label:
     description: >-
       Name of the unique label assigned to the runner.
-      The label is used in two cases:
-      - to use as the input of 'runs-on' property for the following jobs;
-      - to remove the runner from GitHub when it is not needed anymore.
+      Use `label` as the input of `runs-on` workflow property to run subsequent jobs.
+  id:
+    description: >-
+      Unique ID assigned to the runner.
+      Use `id` as input of `runner-id` action property remove the runner from GitHub when it is not needed anymore.
 runs:
   using: node20
   main: ./dist/index.js

--- a/src/config.js
+++ b/src/config.js
@@ -10,7 +10,7 @@ class Config {
       jobSecret: core.getInput('job-secret'),
       backend: core.getInput('backend').toLowerCase(),
       profile: core.getInput('profile').toLowerCase(),
-      label: core.getInput('label')
+      runnerId: core.getInput('runner-id')
     }
 
     // the values of github.context.repo.owner and github.context.repo.repo are taken from
@@ -50,7 +50,7 @@ class Config {
         )
       }
     } else if (this.input.mode === 'stop') {
-      if (!this.input.label) {
+      if (!this.input.runnerId) {
         throw new Error(
           `Not all the required inputs are provided for the 'stop' mode`
         )

--- a/src/gh.js
+++ b/src/gh.js
@@ -45,7 +45,7 @@ async function waitForRunnerRegistered(label) {
       core.info(
         `GitHub self-hosted runner ${runner.name} is registered and ready to use`
       )
-      return
+      return runner.id
     } else {
       waitSeconds += retryIntervalSeconds
       core.info('Checking...')

--- a/src/index.js
+++ b/src/index.js
@@ -3,8 +3,9 @@ const config = require('./config')
 const core = require('@actions/core')
 const { waitForRunnerRegistered } = require('./gh')
 
-function setOutput(label) {
+function setOutput(label, id) {
   core.setOutput('label', label)
+  core.setOutput('id', id)
 }
 
 async function start() {
@@ -18,14 +19,16 @@ async function start() {
   const instance_id = wait_instance_response.start.instance_id
   core.info(`${provider} instance started with ID: ${instance_id}`)
 
-  setOutput(start_instance_response.runner_name)
+  const runner_id = await waitForRunnerRegistered(
+    start_instance_response.runner_name
+  )
 
-  await waitForRunnerRegistered(start_instance_response.runner_name)
+  setOutput(start_instance_response.runner_name, runner_id)
 }
 
 async function stop() {
   const stop_instance_response = await slab.terminateInstanceRequest(
-    config.input.label
+    config.input.runnerId
   )
   await slab.waitForInstance(stop_instance_response.task_id, 'stop')
 

--- a/src/slab.js
+++ b/src/slab.js
@@ -103,11 +103,11 @@ async function waitForInstance(taskId, taskName) {
   }
 }
 
-async function terminateInstanceRequest(runnerName) {
+async function terminateInstanceRequest(runnerId) {
   const url = config.input.slabUrl
 
   const payload = {
-    runner_name: runnerName,
+    runner_id: parseInt(runnerId, 10),
     action: 'terminate',
     sha: config.githubContext.sha,
     git_ref: config.githubContext.ref
@@ -117,7 +117,7 @@ async function terminateInstanceRequest(runnerName) {
   const signature = getSignature(body)
 
   try {
-    core.info(`Request instance termination (runner: ${runnerName})`)
+    core.info(`Request instance termination (runner ID: ${runnerId})`)
 
     const response = await fetch(concat_path(url, 'job'), {
       method: 'POST',


### PR DESCRIPTION
BREAKING CHANGE: runner name cannot be used anymore to remove it from GitHub platform.

A runner can be removed directly, through the REST API, using its ID. This change has been made to avoid Slab server to fetch all registered runners before being able to filter by name and finally find ID of the runner to remove.

> CI will fail as long as Slab is not updated to handle `stop` mode with `runner-id` as input.