### PR TITLE
chore(ci): fix runner removal checks

### DIFF
--- a/.github/workflows/removed_runner.yml
+++ b/.github/workflows/removed_runner.yml
@@ -20,18 +20,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: List runners
-        run: |
-          echo "RUNNERS_FOUND=$(gh api "repos/zama-ai/slab-github-runner/actions/runners" --jq '.runners[].name')" >> "${GITHUB_ENV}"
-        env:
-          GH_TOKEN: ${{ secrets.READ_REPO_TOKEN }}
-
       - name: Check runner removed
         if: inputs.must-exist == false
         run: |
-          ( echo "${{ env.RUNNERS_FOUND }}" | grep --line-regexp -q "${{ inputs.runner-name }}" ) && { exit 1; } || exit 0
+          ( gh api "repos/zama-ai/slab-github-runner/actions/runners" --jq '.runners[].name' | grep --line-regexp -q "${{ inputs.runner-name }}" ) && { exit 1; } || exit 0
+        env:
+          GH_TOKEN: ${{ secrets.READ_REPO_TOKEN }}
 
       - name: Check runner persists
         if: inputs.must-exist == true
         run: |
-          ( echo "${{ env.RUNNERS_FOUND }}" | grep --line-regexp -q "${{ inputs.runner-name }}" ) || exit 1
+          ( gh api "repos/zama-ai/slab-github-runner/actions/runners" --jq '.runners[].name' | grep --line-regexp -q "${{ inputs.runner-name }}" ) || exit 1
+        env:
+          GH_TOKEN: ${{ secrets.READ_REPO_TOKEN }}

--- a/.github/workflows/test_spawn_terminate.yml
+++ b/.github/workflows/test_spawn_terminate.yml
@@ -82,12 +82,22 @@ jobs:
           job-secret: ${{ secrets.JOB_SECRET }}
           label: ${{ matrix.runner }}
 
-  test-runner-removed:
-    name: Test runner is removed
-    needs: [ action-stop ]
+  test-runner-removed-aws:
+    name: Test runner is removed (AWS)
+    needs: [ action-start, action-stop ]
     uses: ./.github/workflows/removed_runner.yml
     with:
-      runner-name: ci-persistent-runner
+      runner-name: ${{ needs.action-start.outputs.runner-aws }}
+      must-exist: false
+    secrets:
+      READ_REPO_TOKEN: ${{ secrets.SLAB_ACTION_TOKEN }}
+
+  test-runner-removed-hyperstack:
+    name: Test runner is removed (Hyperstack)
+    needs: [ action-start, action-stop ]
+    uses: ./.github/workflows/removed_runner.yml
+    with:
+      runner-name: ${{ needs.action-start.outputs.runner-hyperstack }}
       must-exist: false
     secrets:
       READ_REPO_TOKEN: ${{ secrets.SLAB_ACTION_TOKEN }}


### PR DESCRIPTION
This check must be done for each runner registered on the fly (aws + hyperstack). 
Also make runner listing through GitHub CLI more robust.