### PR TITLE
fix(action): retry start stop requests at least 3 times

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,33 +10,68 @@ function setOutput(label) {
 async function start() {
   const provider = config.input.backend
 
-  const start_instance_response = await slab.startInstanceRequest()
+  let start_instance_response
+
+  for (let i = 1; i <= 3; i++) {
+    try {
+      start_instance_response = await slab.startInstanceRequest()
+      break
+    } catch (error) {
+      core.info('Retrying request now...')
+    }
+
+    if (i === 3) {
+      core.setFailed(
+        `${provider} instance start request has failed after 3 attempts`
+      )
+    }
+  }
+
+  setOutput(start_instance_response.runner_name)
+
   core.info(
     `${provider} instance details: ${JSON.stringify(
       start_instance_response.details
     )}`
   )
 
-  const wait_instance_response = await slab.waitForInstance(
-    start_instance_response.task_id,
-    'start'
-  )
+  try {
+    const wait_instance_response = await slab.waitForInstance(
+      start_instance_response.task_id,
+      'start'
+    )
 
-  const instance_id = wait_instance_response.start.instance_id
-  core.info(`${provider} instance started with ID: ${instance_id}`)
+    const instance_id = wait_instance_response.start.instance_id
+    core.info(`${provider} instance started with ID: ${instance_id}`)
 
-  setOutput(start_instance_response.runner_name)
-
-  await waitForRunnerRegistered(start_instance_response.runner_name)
+    await waitForRunnerRegistered(start_instance_response.runner_name)
+  } catch (error) {
+    core.info(`Clean up after error, stop ${provider} instance`)
+    await slab.stopInstanceRequest(start_instance_response.runner_name)
+  }
 }
 
 async function stop() {
-  const stop_instance_response = await slab.terminateInstanceRequest(
-    config.input.label
-  )
+  let stop_instance_response
+
+  for (let i = 1; i <= 3; i++) {
+    try {
+      stop_instance_response = await slab.stopInstanceRequest(
+        config.input.label
+      )
+      break
+    } catch (error) {
+      core.info('Retrying request now...')
+    }
+
+    if (i === 3) {
+      core.setFailed(`Instance stop request has failed after 3 attempts`)
+    }
+  }
+
   await slab.waitForInstance(stop_instance_response.task_id, 'stop')
 
-  core.info('Instance successfully terminated')
+  core.info('Instance successfully stopped')
 }
 
 async function run() {


### PR DESCRIPTION
This is done to prevent possible errors du to network of Slab CI server.
This also performs a cleanup if start request has succeeded but not the rest of the process to avoid zombie instances.