### PR TITLE
chore(ci): add release workflow using semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+# Release new version of Slab action.
+name: Release Slab action
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          fetch-depth: 0
+
+      - name: Do release
+        uses: codfish/semantic-release-action@b621d34fabe0940f031e89b6ebfea28322892a10
+        with:
+          branches: main
+          additional_packages: |
+            [
+              '@semantic-release/github',
+              '@semantic-release/git',
+              '@semantic-release/changelog',
+            ]
+        env:
+          GITHUB_TOKEN: ${{ secrets.SLAB_ACTIONS_TOKEN }}

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,31 @@
+{
+  "tagFormat": "v${version}",
+  "verifyConditions": ["@semantic-release/github"],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "CHANGELOG.md",
+        "changelogTitle": "# Slab Action Changelog"
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["CHANGELOG.md", "Cargo.toml"]
+      }
+    ],
+    [
+      "@semantic-release/github",
+      {
+        "assets": [
+          {
+            "path": "CHANGELOG.md"
+          }
+        ]
+      }
+    ]
+  ]
+}


### PR DESCRIPTION
This is the same-ish workflow than the one used to release a new version of Slab.