### PR TITLE
chore(ci): fix typo in GITHUB_TOKEN associated secret

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,4 +27,4 @@ jobs:
               '@semantic-release/changelog',
             ]
         env:
-          GITHUB_TOKEN: ${{ secrets.SLAB_ACTIONS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SLAB_ACTION_TOKEN }}


### PR DESCRIPTION
This should be the last one.