### PR TITLE
chore(ci): create common workflow for spawn-terminate operations

### DIFF
--- a/.github/workflows/spawn_terminate_common.yml
+++ b/.github/workflows/spawn_terminate_common.yml
@@ -1,0 +1,96 @@
+# Common workflow for spawn and terminate tests
+name: spawn_terminate_common
+
+on:
+  workflow_call:
+    inputs:
+      backend:
+        type: string
+        required: true
+      profile:
+        type: string
+        required: true
+    secrets:
+      REPO_CHECKOUT_TOKEN:
+        required: true
+      SLAB_ACTION_TOKEN:
+        required: true
+      SLAB_URL:
+        required: true
+      JOB_SECRET:
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  action-start:
+    name: GitHub Actions Test (spawn)
+    runs-on: ubuntu-latest
+    outputs:
+      runner: ${{ steps.gen-output.outputs.runner }}
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: 'false'
+          token: ${{ secrets.REPO_CHECKOUT_TOKEN }}
+
+      - name: Test start instance
+        id: test-start
+        uses: ./
+        with:
+          mode: start
+          github-token: ${{ secrets.SLAB_ACTION_TOKEN }}
+          slab-url: ${{ secrets.SLAB_URL }}
+          job-secret: ${{ secrets.JOB_SECRET }}
+          backend: ${{ inputs.backend }}
+          profile: ${{ inputs.profile }}
+
+      - name: Generate output
+        id: gen-output
+        run: |
+          echo "runner=${RUNNER}" >> "${GITHUB_OUTPUT}"
+        env:
+          RUNNER: ${{ steps.test-start.outputs.label }}
+
+  test-runner-alive:
+    name: Test runner is alive
+    needs: [action-start]
+    uses: ./.github/workflows/registered_runner.yml
+    with:
+      runner-name: ${{ needs.action-start.outputs.runner }}
+
+  action-stop:
+    name: GitHub Actions Test (terminate)
+    runs-on: ubuntu-latest
+    needs: [action-start, test-runner-alive]
+    if: ${{ always() && needs.action-start.result != 'skipped' }}
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: 'false'
+          token: ${{ secrets.REPO_CHECKOUT_TOKEN }}
+
+      - name: Test stop instance
+        id: test-stop
+        uses: ./
+        with:
+          mode: stop
+          github-token: ${{ secrets.SLAB_ACTION_TOKEN }}
+          slab-url: ${{ secrets.SLAB_URL }}
+          job-secret: ${{ secrets.JOB_SECRET }}
+          label: ${{ needs.action-start.outputs.runner }}
+
+  test-runner-removed:
+    name: Test runner is removed
+    needs: [action-start, action-stop]
+    uses: ./.github/workflows/removed_runner.yml
+    with:
+      runner-name: ${{ needs.action-start.outputs.runner }}
+      must-exist: false
+    secrets:
+      READ_REPO_TOKEN: ${{ secrets.REPO_CHECKOUT_TOKEN }}

--- a/.github/workflows/test_spawn_terminate.yml
+++ b/.github/workflows/test_spawn_terminate.yml
@@ -16,102 +16,26 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  action-start:
-    name: GitHub Actions Test (spawn)
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        provider: [aws, hyperstack]
-      fail-fast: false
-    outputs:
-      runner-aws: ${{ steps.gen-output.outputs.runner_aws }}
-      runner-hyperstack: ${{ steps.gen-output.outputs.runner_hyperstack }}
-    steps:
-      - name: Checkout
-        id: checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Test start instance
-        id: test-start
-        uses: ./
-        with:
-          mode: start
-          github-token: ${{ secrets.SLAB_ACTION_TOKEN }}
-          slab-url: ${{ secrets.SLAB_BASE_URL_PRE_PROD }}
-          job-secret: ${{ secrets.JOB_SECRET }}
-          backend: ${{ matrix.provider }}
-          profile: ci-test
-
-      - name: Generate output
-        id: gen-output
-        run: |
-          echo "runner_${PROVIDER}=${RUNNER_NAME}" >> "${GITHUB_OUTPUT}"
-        env:
-          RUNNER_NAME: ${{ steps.test-start.outputs.label }}
-          PROVIDER: ${{ matrix.provider }}
-
-  test-runner-alive-aws:
-    name: Test runner is alive (AWS)
-    needs: [action-start]
-    uses: ./.github/workflows/registered_runner.yml
+  aws-provider:
+    name: test_spawn_terminate/aws-provider (bpr)
+    uses: ./.github/workflows/spawn_terminate_common.yml
     with:
-      runner-name: ${{ needs.action-start.outputs.runner-aws }}
-
-  test-runner-alive-hyperstack:
-    name: Test runner is alive (Hyperstack)
-    needs: [action-start]
-    uses: ./.github/workflows/registered_runner.yml
-    with:
-      runner-name: ${{ needs.action-start.outputs.runner-hyperstack }}
-
-  action-stop:
-    name: GitHub Actions Test (terminate)
-    runs-on: ubuntu-latest
-    needs: [action-start, test-runner-alive-aws, test-runner-alive-hyperstack]
-    if: ${{ always() && needs.action-start.result != 'skipped' }}
-    strategy:
-      matrix:
-        runner:
-          [
-            '${{ needs.action-start.outputs.runner-aws }}',
-            '${{ needs.action-start.outputs.runner-hyperstack }}'
-          ]
-      fail-fast: false
-    steps:
-      - name: Checkout
-        id: checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Test stop instance
-        id: test-stop
-        uses: ./
-        with:
-          mode: stop
-          github-token: ${{ secrets.SLAB_ACTION_TOKEN }}
-          slab-url: ${{ secrets.SLAB_BASE_URL_PRE_PROD }}
-          job-secret: ${{ secrets.JOB_SECRET }}
-          label: ${{ matrix.runner }}
-
-  test-runner-removed-aws:
-    name: Test runner is removed (AWS)
-    needs: [action-start, action-stop]
-    uses: ./.github/workflows/removed_runner.yml
-    with:
-      runner-name: ${{ needs.action-start.outputs.runner-aws }}
-      must-exist: false
+      backend: aws
+      profile: ci-test
     secrets:
-      READ_REPO_TOKEN: ${{ secrets.SLAB_ACTION_TOKEN }}
+      REPO_CHECKOUT_TOKEN: ${{ secrets.REPO_CHECKOUT_TOKEN }}
+      JOB_SECRET: ${{ secrets.JOB_SECRET }}
+      SLAB_ACTION_TOKEN: ${{ secrets.SLAB_ACTION_TOKEN }}
+      SLAB_URL: ${{ secrets.SLAB_BASE_URL_PRE_PROD }}
 
-  test-runner-removed-hyperstack:
-    name: Test runner is removed (Hyperstack)
-    needs: [action-start, action-stop]
-    uses: ./.github/workflows/removed_runner.yml
+  hyperstack-provider:
+    name: test_spawn_terminate/hyperstack-provider (bpr)
+    uses: ./.github/workflows/spawn_terminate_common.yml
     with:
-      runner-name: ${{ needs.action-start.outputs.runner-hyperstack }}
-      must-exist: false
+      backend: hyperstack
+      profile: ci-test
     secrets:
-      READ_REPO_TOKEN: ${{ secrets.SLAB_ACTION_TOKEN }}
+      REPO_CHECKOUT_TOKEN: ${{ secrets.REPO_CHECKOUT_TOKEN }}
+      JOB_SECRET: ${{ secrets.JOB_SECRET }}
+      SLAB_ACTION_TOKEN: ${{ secrets.SLAB_ACTION_TOKEN }}
+      SLAB_URL: ${{ secrets.SLAB_BASE_URL_PRE_PROD }}


### PR DESCRIPTION
More spawn and terminate tests will be added soon to the CI pipeline. To avoid handling cases using matrixes we rely on a sub-workflow to run this kind of test.