### PR TITLE
fix: make config accessible to cleanup function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,14 @@
 
 ## [1.6.1](https://github.com/zama-ai/slab-github-runner/compare/v1.6.0...v1.6.1) (2026-05-11)
 
-
 ### Bug Fixes
 
-* **package:** use es javascript build model ([027ef82](https://github.com/zama-ai/slab-github-runner/commit/027ef822edecdce4b068ed9eebb609b7fbe7fcec))
-* pass config as input argument where requested ([4365b1a](https://github.com/zama-ai/slab-github-runner/commit/4365b1a335e289514344199302c4a38b12fba707))
-* **slab:** pass missing argument to get signature function ([224febc](https://github.com/zama-ai/slab-github-runner/commit/224febcdf35ba871c4e5af19dbcec5ef8ae1efb3))
+- **package:** use es javascript build model
+  ([027ef82](https://github.com/zama-ai/slab-github-runner/commit/027ef822edecdce4b068ed9eebb609b7fbe7fcec))
+- pass config as input argument where requested
+  ([4365b1a](https://github.com/zama-ai/slab-github-runner/commit/4365b1a335e289514344199302c4a38b12fba707))
+- **slab:** pass missing argument to get signature function
+  ([224febc](https://github.com/zama-ai/slab-github-runner/commit/224febcdf35ba871c4e5af19dbcec5ef8ae1efb3))
 
 # [1.6.0](https://github.com/zama-ai/slab-github-runner/compare/v1.5.1...v1.6.0) (2026-03-31)
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -54072,12 +54072,14 @@ function src_setOutput(label) {
   setOutput('label', label)
 }
 
+// Global variables meant to be used by cleanup function.
+let conf
 let runnerName
 
 async function cleanup() {
   if (runnerName) {
     info('Stop instance after cancellation')
-    await slab.stopInstanceRequest(runnerName)
+    await slab.stopInstanceRequest(conf, runnerName)
   }
 }
 
@@ -54191,9 +54193,9 @@ async function stop(config) {
 
 async function run() {
   try {
-    const config = new Config()
+    conf = new Config()
 
-    config.input.mode === 'start' ? await start(config) : await stop(config)
+    conf.input.mode === 'start' ? await start(conf) : await stop(conf)
   } catch (error) {
     setFailed(error.message)
   }

--- a/src/index.js
+++ b/src/index.js
@@ -13,12 +13,14 @@ function setOutput(label) {
   coreSetOutput('label', label)
 }
 
+// Global variables meant to be used by cleanup function.
+let conf
 let runnerName
 
 async function cleanup() {
   if (runnerName) {
     setInfo('Stop instance after cancellation')
-    await slab.stopInstanceRequest(runnerName)
+    await slab.stopInstanceRequest(conf, runnerName)
   }
 }
 
@@ -132,9 +134,9 @@ async function stop(config) {
 
 async function run() {
   try {
-    const config = new Config()
+    conf = new Config()
 
-    config.input.mode === 'start' ? await start(config) : await stop(config)
+    conf.input.mode === 'start' ? await start(conf) : await stop(conf)
   } catch (error) {
     setFailed(error.message)
   }


### PR DESCRIPTION
Assigning the action configuration to a global variable makes the cleanup function able to perform its duty.